### PR TITLE
fix issues about NVP flow

### DIFF
--- a/viabel/optimization.py
+++ b/viabel/optimization.py
@@ -82,6 +82,8 @@ class StochasticGradientOptimizer(Optimizer):
                     object_val, object_grad = objective(variational_param)
                     descent_dir = self.descent_direction(object_grad)
                     variational_param -= self._learning_rate * descent_dir
+                    if len(variational_param.shape) == 2:
+                        variational_param *= 0.9999
                     # record state information
                     value_history.append(object_val)
                     if self._diagnostics or iap is not None:
@@ -277,7 +279,7 @@ class FASO(Optimizer):
                                 iterate_average_k_history.append(k)
                                 iterate_average_history.append(iterate_average)
                             if R_hat_success:
-                                k_Rhat = k								
+                                k_Rhat = k
                                 k_conv = k - best_W
                                 W_check = best_W  # immediately check MCSE
 


### PR DESCRIPTION
In this PR, I modify several issues related to NVPFlow.

- There was a bug in NeuralNet. The non-linear activation was only applied to the last layer while the gradient of the non-linear activation was only computed on the intermediate layers. 
```
        for l in range(self._layers):
            W = var_param[str(l)]
            x = np.dot(x, W)
            log_det_J += np.log(np.abs(np.dot(derivative(x), W.T).sum(axis = 1)))
        return self._nonlinearity(x), log_det_J
```
The bug is fixed now.
- Added a feature to NeuralNet. Now the intermediate layers and the last layer can use different activation functions. 
- Fixed several bugs in NVPFlow, concluding the computation of `log_density` and `entropy`(removed).
- Added weight decay to the StochasticGradientOptimizer. 